### PR TITLE
Refactor Task Interface and Component Structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+*.code-workspace

--- a/src/components/ArmPreview.tsx
+++ b/src/components/ArmPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Task } from '../pages/BuilderPage';
+import { Task } from '@/schemas/taskSchemas';
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Canvas } from '@react-three/fiber';

--- a/src/components/ExportModal.tsx
+++ b/src/components/ExportModal.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { Task } from '../pages/BuilderPage';
+import { Task } from '@/schemas/taskSchemas';
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Card } from "@/components/ui/card";

--- a/src/components/TaskBlockEditor.tsx
+++ b/src/components/TaskBlockEditor.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { DndContext, closestCenter, DragEndEvent } from '@dnd-kit/core';
 import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { Task } from '../pages/BuilderPage';
+import { Task } from '@/schemas/taskSchemas';
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Trash2, Plus, GripVertical } from 'lucide-react';

--- a/src/components/TaskBlockEditor.tsx
+++ b/src/components/TaskBlockEditor.tsx
@@ -19,7 +19,7 @@ const TaskComponentMap = {
   release: TaskRelease,
 } as const;
 
-type TaskType = 'move' | 'grip' | 'release' | 'wait';
+type TaskType = keyof typeof TaskComponentMap;
 
 interface TaskBlockEditorProps {
   taskList: Task[];
@@ -135,10 +135,11 @@ const TaskBlockEditor: React.FC<TaskBlockEditorProps> = ({ taskList, setTaskList
       <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center">
         <p className="text-sm font-medium text-gray-600 mb-2">Add Task Block:</p>
         <div className="flex flex-wrap gap-3 justify-center">
-          <Button onClick={() => addTask('move')}>MoveTo</Button>
-          <Button onClick={() => addTask('grip')}>Grip</Button>
-          <Button onClick={() => addTask('release')}>Release</Button>
-          <Button onClick={() => addTask('wait')}>Wait</Button>
+          {Object.keys(TaskComponentMap).map((type) => (
+            <Button key={type} onClick={() => addTask(type as TaskType)}>
+              {type.charAt(0).toUpperCase() + type.slice(1)}
+            </Button>
+          ))}
         </div>
       </div>
 

--- a/src/components/tasks/TaskGrip.tsx
+++ b/src/components/tasks/TaskGrip.tsx
@@ -32,7 +32,12 @@ const TaskGrip: React.FC<TaskCompProps> = ({ task, onUpdate }) => {
           max={100}
           step={1}
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => {
+            const next = e.target.value;
+            if (/^-?\d*\.?\d*$/.test(next)) {
+              setDraft(next);
+            }
+          }}
           onBlur={() => handleCommit(parseFloat(draft))}
           onKeyDown={(e) => {
             if (e.key === 'Enter') handleCommit(parseFloat(draft));

--- a/src/components/tasks/TaskGrip.tsx
+++ b/src/components/tasks/TaskGrip.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Task } from '../../pages/BuilderPage';
+import { DESC_FORMAT } from '@/schemas/taskSchemas';
+
+interface TaskCompProps {
+    task: Task;
+    onUpdate: (newTask: Task) => void;
+  }
+
+const TaskGrip: React.FC<TaskCompProps> = ({ task, onUpdate }) => {
+  const handleCommit = (val: number) => {
+    const clamped = Math.max(0, Math.min(100, val));
+    const newParams = { ...task.parameters, force: clamped };
+    const newDesc = DESC_FORMAT.grip(newParams);
+    onUpdate({ ...task, parameters: newParams, description: newDesc });
+  };
+
+  const [draft, setDraft] = React.useState<string>(
+    String(task.parameters.force ?? 0)
+  );
+  React.useEffect(() => {
+    setDraft(String(task.parameters.force ?? 0));
+  }, [task.parameters.force]);
+
+  return (
+    <div className="ml-8 mt-2 space-y-2">
+      <div className="flex items-center space-x-2">
+        <label className="w-24 text-sm text-gray-600">Force (%)</label>
+        <input
+          type="number"
+          min={0}
+          max={100}
+          step={1}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => handleCommit(parseFloat(draft))}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') handleCommit(parseFloat(draft));
+            const allowed = [
+              '-',
+              '.',
+              'Backspace',
+              'Delete',
+              'ArrowLeft',
+              'ArrowRight',
+              'Tab',
+            ];
+            if (allowed.includes(e.key) || /^[0-9]$/.test(e.key)) {
+              e.stopPropagation();
+            } else {
+              e.preventDefault();
+            }
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          className="w-32 rounded border px-2 py-1 text-sm"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TaskGrip;

--- a/src/components/tasks/TaskMove.tsx
+++ b/src/components/tasks/TaskMove.tsx
@@ -55,7 +55,12 @@ const TaskMove: React.FC<TaskCompProps> = ({ task, onUpdate }) => {
           max={spec.max}
           step={step}
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
+          onChange={(e) => {
+            const next = e.target.value;
+            if (/^-?\d*\.?\d*$/.test(next)) {
+              setDraft(next);
+            }
+          }}
           onBlur={commit}
           onKeyDown={(e) => {
             if (e.key === 'Enter') commit();

--- a/src/components/tasks/TaskMove.tsx
+++ b/src/components/tasks/TaskMove.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { Task } from '../../pages/BuilderPage';
+import { TASK_SCHEMAS, DESC_FORMAT } from '@/schemas/taskSchemas';
+
+const MOVE_SCHEMA = TASK_SCHEMAS.move;
+type Axis = keyof typeof MOVE_SCHEMA;  // 'x' | 'y' | 'z'
+
+interface TaskCompProps {
+  task: Task;
+  onUpdate: (updated: Task) => void;
+}
+
+const TaskMove: React.FC<TaskCompProps> = ({ task, onUpdate }) => {
+  /** Convert UI cm → m and update parent */
+  const applyChange = (axis: Axis, uiCm: number) => {
+    const metres = MOVE_SCHEMA[axis].toInternal?.(uiCm) ?? uiCm;
+    const newParams = { ...task.parameters, [axis]: metres };
+    const newDesc = DESC_FORMAT.move(newParams);
+    onUpdate({ ...task, parameters: newParams, description: newDesc });
+  };
+
+  /** Field factory for X,Y,Z */
+  const Field = (axis: Axis) => {
+    const spec = MOVE_SCHEMA[axis];
+    const step = (spec as { step?: number }).step ?? 1;
+    const toUI = spec.toUI ?? ((v: number) => v);
+
+    const [draft, setDraft] = React.useState(() =>
+      String(toUI((task.parameters[axis] as number) ?? 0))
+    );
+
+    React.useEffect(() => {
+      const next = String(toUI((task.parameters[axis] as number) ?? 0));
+      if (next !== draft) setDraft(next);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [task.parameters[axis]]);
+
+    const commit = () => {
+      const num = Number(draft);
+      if (!Number.isNaN(num)) applyChange(axis, num);
+    };
+
+    return (
+      <div className="flex items-center space-x-2" key={axis}>
+        <label
+          htmlFor={`${task.id}-${axis}`}
+          className="w-20 text-sm text-gray-600"
+        >
+          {spec.label} ({spec.unit})
+        </label>
+        <input
+          id={`${task.id}-${axis}`}
+          type="number"
+          min={spec.min}
+          max={spec.max}
+          step={step}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commit();
+            const ok =
+              ['-', '.', 'Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'].includes(e.key) ||
+              /^[0-9]$/.test(e.key);
+            if (ok) e.stopPropagation();
+            else e.preventDefault();
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          className="w-24 rounded border px-2 py-1 text-sm"
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div className="ml-8 mt-2 space-y-2">
+      {Field('x')}
+      {Field('y')}
+      {Field('z')}
+    </div>
+  );
+};
+
+export default TaskMove;

--- a/src/components/tasks/TaskRelease.tsx
+++ b/src/components/tasks/TaskRelease.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const TaskRelease: React.FC = () => {
+  return (
+    <p className="ml-8 mt-2 text-sm text-gray-500 italic">
+      Release gripper – no parameters
+    </p>
+  );
+};
+
+export default TaskRelease;

--- a/src/components/tasks/TaskWait.tsx
+++ b/src/components/tasks/TaskWait.tsx
@@ -4,23 +4,24 @@ import { DESC_FORMAT } from '@/schemas/taskSchemas';
 
 interface TaskCompProps {
   task: Task;
-  onUpdate: (idx: number, newTask: Task) => void;
+  onUpdate: (newTask: Task) => void;
 }
 
 const TaskWait: React.FC<TaskCompProps> = ({ task, onUpdate }) => {
-  const commit = (val: number) => {
+  const [draft, setDraft] = React.useState<string>(
+    String(task.parameters.duration ?? 1)
+  );
+
+  React.useEffect(() => {
+    setDraft(String(task.parameters.duration ?? 1));
+  }, [task.parameters.duration]);
+
+  const handleCommit = (val: number) => {
     const clamped = Math.max(0.1, Math.min(600, val));
     const newParams = { ...task.parameters, duration: clamped };
     const newDesc = DESC_FORMAT.wait(newParams);
     onUpdate({ ...task, parameters: newParams, description: newDesc });
   };
-
-  const [draft, setDraft] = React.useState<string>(
-    String(task.parameters.duration ?? 0)
-  );
-  React.useEffect(() => {
-    setDraft(String(task.parameters.duration ?? 0));
-  }, [task.parameters.duration]);
 
   return (
     <div className="ml-8 mt-2 space-y-2">
@@ -32,18 +33,16 @@ const TaskWait: React.FC<TaskCompProps> = ({ task, onUpdate }) => {
           max={600}
           step={0.1}
           value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={() => commit(parseFloat(draft))}
+          onChange={(e) => {
+            const next = e.target.value;
+            if (/^-?\d*\.?\d*$/.test(next)) {
+              setDraft(next);
+            }
+          }}
+          onBlur={() => handleCommit(parseFloat(draft))}
           onKeyDown={(e) => {
-            if (e.key === 'Enter') commit(parseFloat(draft));
             const allowed = [
-              '-',
-              '.',
-              'Backspace',
-              'Delete',
-              'ArrowLeft',
-              'ArrowRight',
-              'Tab',
+              '-', '.', 'Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab',
             ];
             if (allowed.includes(e.key) || /^[0-9]$/.test(e.key)) {
               e.stopPropagation();

--- a/src/components/tasks/TaskWait.tsx
+++ b/src/components/tasks/TaskWait.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Task } from '../../pages/BuilderPage';
+import { DESC_FORMAT } from '@/schemas/taskSchemas';
+
+interface TaskCompProps {
+  task: Task;
+  onUpdate: (idx: number, newTask: Task) => void;
+}
+
+const TaskWait: React.FC<TaskCompProps> = ({ task, onUpdate }) => {
+  const commit = (val: number) => {
+    const clamped = Math.max(0.1, Math.min(600, val));
+    const newParams = { ...task.parameters, duration: clamped };
+    const newDesc = DESC_FORMAT.wait(newParams);
+    onUpdate({ ...task, parameters: newParams, description: newDesc });
+  };
+
+  const [draft, setDraft] = React.useState<string>(
+    String(task.parameters.duration ?? 0)
+  );
+  React.useEffect(() => {
+    setDraft(String(task.parameters.duration ?? 0));
+  }, [task.parameters.duration]);
+
+  return (
+    <div className="ml-8 mt-2 space-y-2">
+      <div className="flex items-center space-x-2">
+        <label className="w-28 text-sm text-gray-600">Duration (s)</label>
+        <input
+          type="number"
+          min={0.1}
+          max={600}
+          step={0.1}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => commit(parseFloat(draft))}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') commit(parseFloat(draft));
+            const allowed = [
+              '-',
+              '.',
+              'Backspace',
+              'Delete',
+              'ArrowLeft',
+              'ArrowRight',
+              'Tab',
+            ];
+            if (allowed.includes(e.key) || /^[0-9]$/.test(e.key)) {
+              e.stopPropagation();
+            } else {
+              e.preventDefault();
+            }
+          }}
+          onPointerDown={(e) => e.stopPropagation()}
+          className="w-32 rounded border px-2 py-1 text-sm"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default TaskWait;

--- a/src/pages/BuilderPage.tsx
+++ b/src/pages/BuilderPage.tsx
@@ -1,5 +1,6 @@
 
 import React, { useState } from 'react';
+import { getDefaultParams, DESC_FORMAT } from '@/schemas/taskSchemas';
 import TaskBlockEditor from '../components/TaskBlockEditor';
 import ArmPreview from '../components/ArmPreview';
 import ExportModal from '../components/ExportModal';
@@ -16,14 +17,14 @@ const BuilderPage = () => {
     {
       id: '1',
       type: 'move',
-      parameters: { x: 1, y: 3, z: 2 },
-      description: 'Move to position (1, 3, 2)'
+      parameters: getDefaultParams('move'),
+      description: DESC_FORMAT.move(getDefaultParams('move'))
     },
     {
       id: '2',
       type: 'grip',
-      parameters: { force: 50 },
-      description: 'Grip with 50% force'
+      parameters: getDefaultParams('grip'),
+      description: DESC_FORMAT.grip(getDefaultParams('grip'))
     }
   ]);
 

--- a/src/pages/BuilderPage.tsx
+++ b/src/pages/BuilderPage.tsx
@@ -4,13 +4,7 @@ import { getDefaultParams, DESC_FORMAT } from '@/schemas/taskSchemas';
 import TaskBlockEditor from '../components/TaskBlockEditor';
 import ArmPreview from '../components/ArmPreview';
 import ExportModal from '../components/ExportModal';
-
-export interface Task {
-  id: string;
-  type: string;
-  parameters: Record<string, any>;
-  description: string;
-}
+import { Task } from '@/schemas/taskSchemas';
 
 const BuilderPage = () => {
   const [taskList, setTaskList] = useState<Task[]>([

--- a/src/schemas/taskSchemas.ts
+++ b/src/schemas/taskSchemas.ts
@@ -25,9 +25,9 @@ export interface ParamSpec {
 
 export const DESC_FORMAT: Record<string, (p: Record<string, number>) => string> = {
   move: (p) =>
-    `Move to Position (${((p.x ?? 0) * 100).toFixed(1)} cm, ` +
-    `${((p.y ?? 0) * 100).toFixed(1)} cm, ` +
-    `${((p.z ?? 0) * 100).toFixed(1)} cm)`,
+    `Move to Position (${(p.x ?? 0).toFixed(2)} m, ` +
+    `${(p.y ?? 0).toFixed(2)} m, ` +
+    `${(p.z ?? 0).toFixed(2)} m)`,
 
   grip: (p) => `Grip with ${(p.force ?? 0).toFixed(0)}% force`,
 

--- a/src/schemas/taskSchemas.ts
+++ b/src/schemas/taskSchemas.ts
@@ -1,3 +1,10 @@
+export interface Task {
+  id: string;
+  type: string;
+  parameters: Record<string, any>;
+  description: string;
+}
+
 export interface ParamSpec {
     label: string;          // what to show in UI
     unit?: string;          // optional unit text

--- a/src/schemas/taskSchemas.ts
+++ b/src/schemas/taskSchemas.ts
@@ -1,0 +1,50 @@
+export interface ParamSpec {
+    label: string;          // what to show in UI
+    unit?: string;          // optional unit text
+    min?: number;
+    max?: number;
+    step?: number;
+    toInternal?: (v: number) => number; // UI → model
+    toUI?: (v: number) => number;       // model → UI
+  }
+  
+  export const TASK_SCHEMAS = {
+    move: {
+      x: { label: 'X', unit: 'cm', min: -200, max: 200, toInternal: cm => cm / 100, toUI: m => m * 100 },
+      y: { label: 'Y', unit: 'cm', min: -100, max: 100, toInternal: cm => cm / 100, toUI: m => m * 100 },
+      z: { label: 'Z', unit: 'cm', min:  0,   max: 200, toInternal: cm => cm / 100, toUI: m => m * 100 },
+    },
+    grip: {
+      force: { label: 'Force', unit: '%', min: 0, max: 100, step: 1 },
+    },
+    wait: {
+      duration: { label: 'Duration', unit: 's', min: 0.1, max: 600, step: 0.1 },
+    },
+    release: {},
+  } satisfies Record<string, Record<string, ParamSpec>>;
+
+export const DESC_FORMAT: Record<string, (p: Record<string, number>) => string> = {
+  move: (p) =>
+    `Move to Position (${((p.x ?? 0) * 100).toFixed(1)} cm, ` +
+    `${((p.y ?? 0) * 100).toFixed(1)} cm, ` +
+    `${((p.z ?? 0) * 100).toFixed(1)} cm)`,
+
+  grip: (p) => `Grip with ${(p.force ?? 0).toFixed(0)}% force`,
+
+  release: () => 'Release gripper',
+
+  wait: (p) => `Wait for ${(p.duration ?? 0).toFixed(1)} sec`,
+};
+
+export const DEFAULT_PARAMETERS: Record<keyof typeof TASK_SCHEMAS, Record<string, number>> = {
+  move: { x: 0, y: 0, z: 0 },
+  grip: { force: 50 },
+  release: {},
+  wait: { duration: 1 },
+};
+
+export function getDefaultParams<T extends keyof typeof TASK_SCHEMAS>(
+  type: T
+): Record<string, number> {
+  return JSON.parse(JSON.stringify(DEFAULT_PARAMETERS[type]));
+}


### PR DESCRIPTION
This PR introduces several refactors to improve maintainability and consistency:
	•	Moved Task interface from BuilderPage to the shared taskSchemas module for central access across components.
	•	Unified task type definitions using TaskComponentMap to streamline task rendering and creation logic.
	•	Cleaned up repetitive logic in TaskBlockEditor for adding tasks and improved type safety with keyof typeof.
	•	Ensured all task components (TaskMove, TaskGrip, TaskWait, TaskRelease) use consistent state handling and value validation.
